### PR TITLE
fix: getting not edited content

### DIFF
--- a/src/Cogworks.FindAndReplace/Web/API/FindAndReplaceApiController.cs
+++ b/src/Cogworks.FindAndReplace/Web/API/FindAndReplaceApiController.cs
@@ -58,6 +58,7 @@ namespace Cogworks.FindAndReplace.Web.API
                         INNER JOIN [cmsPropertyType] [upt] ON ([upt].[id] = [upd].[propertyTypeId])
                     WHERE ([cv].[current] = 1)
                         AND ([umbracoDocument].[published] = 1)
+                        AND ([umbracoDocument].[edited] = 0)
                         AND ([umbracoNode].[path] LIKE upper(@contentId))
                         AND
                         (


### PR DESCRIPTION
<!--
Thank you for your pull request, #h5yr! But it's just a beginning. 
Please provide a details where it's required and review the requirements below.
-->
**What this PR does / why it's submitted / why we need it**:

Previous version gets all current content. Umbraco set new version with flag current as new published and draft for backoffice. When we are changing something on draft there is also set flag edited. So we want just to take those content pages that are current but not edited (will explain it more in some blog post how it works). In generally we could take just published version of content by this query:

SELECT
      [VarcharValue]
    , [TextValue]
    , [VersionId]
    , [NodeName]
    , [PropertyAlias]
    , [PropertyName]
FROM
(
    SELECT
        *
    FROM
    (
        SELECT
            *
            ,ROW_NUMBER() OVER (PARTITION BY [NodeName] ORDER BY [versionId] DESC) AS [Rank]
        FROM 
        (
            SELECT
                    [upd].[varcharValue] AS [VarcharValue]
                , [upd].[textValue] AS [TextValue]
                , [cv].[id] AS [VersionId]
                , [pcv].[text] AS [NodeName]
                , [upt].[Alias] AS [PropertyAlias]
                , [upt].[Name] AS [PropertyName]
                , [cv].versionDate AS [VersionDate]
                , [umbracoDocument].[nodeId] AS [NodeId]
            FROM [umbracoDocument]
                INNER JOIN [umbracoContent] ON ([umbracoContent].[nodeId] = [umbracoDocument].[nodeId])
                INNER JOIN [umbracoNode] ON ([umbracoNode].[id] = [umbracoContent].[nodeId])
                INNER JOIN [umbracoContentVersion] [cv] ON ([cv].[nodeId] = [umbracoDocument].[nodeId])
                INNER JOIN [umbracoDocumentVersion] ON ([umbracoDocumentVersion].[id] = [cv].[id])
                LEFT JOIN [umbracoContentVersion] [pcv]
                    INNER JOIN [umbracoDocumentVersion] [pdv] ON (([pdv].[id] = [pcv].[id]) AND [pdv].[published] = 1)
                ON ([pcv].[nodeId] = [umbracoDocument].[nodeId])
                LEFT JOIN [umbracoContentVersionCultureVariation] [ccv]
                    INNER JOIN [umbracoLanguage] [lang] ON (([lang].[id] = [ccv].[languageId]) AND ([lang].[languageISOCode] =N'[[[ISOCODE]]]'))
                ON ([cv].[id] = [ccv].[versionId])
                INNER JOIN [umbracoPropertyData] [upd] ON ([upd].[versionId] = [cv].[id])
                INNER JOIN [cmsPropertyType] [upt] ON ([upt].[id] = [upd].[propertyTypeId])
            WHERE ([cv].[current] = 0)
                AND ([umbracoDocument].[published] = 1)
                AND ([umbracoNode].[path] LIKE upper(@contentId))
                AND
                (
                    (
                        [upd].[textValue] is not null AND [upd].[textValue] LIKE @phrase
                    )
                    OR
                    (
                        [upd].[varcharValue] is not null AND [upd].[varcharValue] LIKE @phrase
                    )
                )
        ) AS [GetAllPublishedVersions]
    ) AS [RankVersionsForContent]
    WHERE [Rank] = 1
) AS [GetLatestPublishedContent]
ORDER BY [NodeId]

but then we will have issue with saving non current page. BTW in the upper query NPoco doesn't allow CTE clausure -> so I translated it to sub-queries.

---

**Checklist**:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My PR has a descriptive title (not a vague title like `Needed this`)
- [x] All the commits follows [commitlint guidelines](https://github.com/conventional-changelog/commitlint#what-is-commitlint)
- [x] My PR targets the `develop` branch or appropriate `release` branch

---
